### PR TITLE
Freeze 3D model for framing tests

### DIFF
--- a/src/sections/Experience3D.jsx
+++ b/src/sections/Experience3D.jsx
@@ -35,6 +35,7 @@ export default function Experience3D() {
   const [loading, setLoading] = useState({ show: false, progress: 0 });
 
   useEffect(() => {
+    console.log("[EXPERIENCE3D] patch ativo");
     // ---------- Base ----------
     const width = mountRef.current.clientWidth;
     const height = mountRef.current.clientHeight;
@@ -43,7 +44,7 @@ export default function Experience3D() {
     scene.background = new THREE.Color("#090a0b");
 
     const camera = new THREE.PerspectiveCamera(30, width / height, 0.01, 100);
-    camera.position.set(0, 0.9, 3.6);
+    camera.position.set(0, 0.9, 8.5); // distância maior para enquadrar o corpo todo
     camera.lookAt(0, 0, 0);
     camera.updateProjectionMatrix();
 
@@ -282,6 +283,8 @@ export default function Experience3D() {
 
     const buildTimeline = (phoneObj) => {
       tl.clear();
+      // travar o modelo para testes de enquadramento
+      if (true) return;
       gsap.set(phoneObj.rotation, { x: 0.12, y: startAngle });
 
       sections.forEach((_, i) => {
@@ -408,6 +411,14 @@ export default function Experience3D() {
 
     const animate = () => {
       reqRef.current = requestAnimationFrame(animate);
+
+      // Garantia: distância e imobilidade enquanto ajusto enquadramento
+      camera.position.z = 8.5; // mesmo valor do passo 2
+      if (phoneRef.current) {
+        phoneRef.current.rotation.set(0, 0, 0);
+        phoneRef.current.position.set(0, 0, 0);
+      }
+
       renderer.render(scene, camera);
     };
     animate();
@@ -437,7 +448,7 @@ export default function Experience3D() {
           // Norm/escala/centro
           const box = new THREE.Box3().setFromObject(phone);
           const size = box.getSize(new THREE.Vector3());
-          const scale = 3.2 / Math.max(size.y || 1e-3, 1e-3);
+          const scale = 1.2 / Math.max(size.y || 1e-3, 1e-3); // modelo menor
           phone.scale.setScalar(scale);
           const center = box.getCenter(new THREE.Vector3());
           phone.position.sub(center.multiplyScalar(1));


### PR DESCRIPTION
## Summary
- log patch activation in Experience3D
- move camera back and shrink model for full-body framing
- disable GSAP timeline and lock camera/model each frame

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689fcc63358883269d5b08e0f7af4389