### PR TITLE
Adjust hero 3D layout and model animation

### DIFF
--- a/src/sections/Services.jsx
+++ b/src/sections/Services.jsx
@@ -33,7 +33,11 @@ export default function Services() {
   }, []);
 
   return (
-    <section id="servicos" ref={containerRef} className="mx-auto max-w-6xl px-6 py-12 md:py-16">
+    <section
+      id="servicos"
+      ref={containerRef}
+      className="relative z-10 -mt-12 md:-mt-20 mx-auto max-w-6xl px-6 py-12 md:py-16"
+    >
       <div className="flex items-end justify-between">
         <h2 className="text-2xl md:text-3xl" style={{ fontFamily: "'Space Grotesk', sans-serif" }}>Serviços</h2>
         <span className="text-xs text-white/50">Atendimento digital e presencial sob consulta</span>


### PR DESCRIPTION
## Summary
- Allow hero canvas to overflow and prevent event capture
- Lower 3D model and retune camera framing
- Offset services section to overlap model legs
- Drop loading overlay and play native GLTF animations

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68a00497b8808326b39e8bbb5a0d35be