### PR TITLE
Adjust hero 3D layout and model alignment

### DIFF
--- a/src/sections/Experience3D.jsx
+++ b/src/sections/Experience3D.jsx
@@ -1,5 +1,5 @@
 // src/sections/Experience3D.jsx
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef } from "react";
 import * as THREE from "three";
 import { RoundedBoxGeometry } from "three/examples/jsm/geometries/RoundedBoxGeometry.js";
 import { RoomEnvironment } from "three/examples/jsm/environments/RoomEnvironment.js";
@@ -9,7 +9,6 @@ import { Button } from "../components/ui/button";
 import { MessageCircle } from "lucide-react";
 import { gsap } from "gsap";
 import { ScrollTrigger } from "gsap/ScrollTrigger";
-import LoadingOverlay from "../components/LoadingOverlay";
 
 gsap.registerPlugin(ScrollTrigger);
 
@@ -32,10 +31,8 @@ export default function Experience3D() {
   const mountRef = useRef(null);
   const phoneRef = useRef(null);
   const reqRef = useRef(null);
-  const [loading, setLoading] = useState({ show: false, progress: 0 });
 
   useEffect(() => {
-    console.log("[EXPERIENCE3D] patch ativo");
     // ---------- Base ----------
     const width = mountRef.current.clientWidth;
     const height = mountRef.current.clientHeight;
@@ -43,9 +40,9 @@ export default function Experience3D() {
     const scene = new THREE.Scene();
     scene.background = new THREE.Color("#090a0b");
 
-    const camera = new THREE.PerspectiveCamera(30, width / height, 0.01, 100);
-    camera.position.set(0, 0.9, 5.5); // distância maior para enquadrar o corpo todo
-    camera.lookAt(0, 0, 0);
+    const camera = new THREE.PerspectiveCamera(35, width / height, 0.01, 100);
+    camera.position.set(0, 1.6, 3);
+    camera.lookAt(0, 1.0, 0);
     camera.updateProjectionMatrix();
 
     const isMobile =
@@ -265,7 +262,7 @@ export default function Experience3D() {
     scene.add(phone);
     attachScreenPlane(phone);
     phone.rotation.set(0.12, -0.2, 0);
-    phone.position.set(0, 0, 0);
+    phone.position.set(0, -0.4, 0);
     phoneRef.current = phone;
 
     // ---------- TIMELINE (scroll-driven) ----------
@@ -283,8 +280,6 @@ export default function Experience3D() {
 
     const buildTimeline = (phoneObj) => {
       tl.clear();
-      // travar o modelo para testes de enquadramento
-      if (true) return;
       gsap.set(phoneObj.rotation, { x: 0.12, y: startAngle });
 
       sections.forEach((_, i) => {
@@ -409,29 +404,19 @@ export default function Experience3D() {
     window.addEventListener("resize", onResize);
     onResize();
 
+    const clock = new THREE.Clock();
+    let mixer = null;
+
     const animate = () => {
       reqRef.current = requestAnimationFrame(animate);
-
-      // Garantia: distância e imobilidade enquanto ajusto enquadramento
-      camera.position.z = 5.5; // mesmo valor do passo 2
-      if (phoneRef.current) {
-        phoneRef.current.rotation.set(0, 0, 0);
-        phoneRef.current.position.set(0, 0, 0);
-      }
-
+      const delta = clock.getDelta();
+      if (mixer) mixer.update(delta);
       renderer.render(scene, camera);
     };
     animate();
 
     // ---------- Loader GLB ----------
-    const manager = new THREE.LoadingManager();
-    manager.onStart = () => setLoading({ show: true, progress: 0 });
-    manager.onProgress = (_url, loaded, total) =>
-      setLoading({ show: true, progress: (loaded / total) * 100 });
-    manager.onError = () => setLoading({ show: false, progress: 100 });
-    manager.onLoad = () => setLoading({ show: false, progress: 100 });
-
-    const loader = new GLTFLoader(manager);
+    const loader = new GLTFLoader();
 
     (async () => {
       const candidates = ["/models/phone.glb", "/models/phone.gltf"];
@@ -452,6 +437,7 @@ export default function Experience3D() {
           phone.scale.setScalar(scale);
           const center = box.getCenter(new THREE.Vector3());
           phone.position.sub(center.multiplyScalar(1));
+          phone.position.y -= 0.4;
 
           // Pose
           phone.rotation.set(0.12, -0.2, 0);
@@ -469,6 +455,13 @@ export default function Experience3D() {
           scene.add(phone);
           attachScreenPlane(phone);
           phoneRef.current = phone;
+
+          if (gltf.animations && gltf.animations.length) {
+            mixer = new THREE.AnimationMixer(phone);
+            gltf.animations.forEach((clip) =>
+              mixer.clipAction(clip).play()
+            );
+          }
 
           // Reconstrói timeline com o modelo final
           buildTimeline(phone);
@@ -497,15 +490,13 @@ export default function Experience3D() {
   return (
     <section
       ref={wrapRef}
-      className="relative h-[100vh] w-full flex items-center justify-center overflow-hidden"
+      className="relative min-h-[100svh] w-full overflow-visible"
     >
       {/* 3D Canvas */}
-      <div ref={mountRef} className="absolute inset-0 z-30" />
-
-      <LoadingOverlay
-        show={loading.show}
-        progress={loading.progress}
-        text="Carregando modelo 3D..."
+      <div
+        ref={mountRef}
+        id="canvas-container"
+        className="absolute inset-0 pointer-events-none z-0 translate-y-24 sm:translate-y-20 md:translate-y-8"
       />
 
       {/* Cinematic vignette */}

--- a/src/sections/Services.jsx
+++ b/src/sections/Services.jsx
@@ -33,7 +33,11 @@ export default function Services() {
   }, []);
 
   return (
-    <section id="servicos" ref={containerRef} className="mx-auto max-w-6xl px-6 py-12 md:py-16">
+    <section
+      id="servicos"
+      ref={containerRef}
+      className="relative z-10 -mt-12 md:-mt-20 mx-auto max-w-6xl px-6 py-12 md:py-16"
+    >
       <div className="flex items-end justify-between">
         <h2 className="text-2xl md:text-3xl" style={{ fontFamily: "'Space Grotesk', sans-serif" }}>Serviços</h2>
         <span className="text-xs text-white/50">Atendimento digital e presencial sob consulta</span>


### PR DESCRIPTION
## Summary
- Allow hero canvas to overflow and prevent event capture
- Lower 3D model, retune camera framing, and enable model animations
- Offset services section to overlap model legs
- Remove loading overlay so canvas doesn't block interactions

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68a00497b8808326b39e8bbb5a0d35be